### PR TITLE
fix(service): use default backend that can change paths and ports

### DIFF
--- a/aws-managed/lb-fargate-service/v1/schema/schema.yaml
+++ b/aws-managed/lb-fargate-service/v1/schema/schema.yaml
@@ -33,7 +33,7 @@ schema:
         image:
           type: string
           description: "The name/url of the container image"
-          default: "public.ecr.aws/z9d2n7e1/nginx:1.19.5"          
+          default: "public.ecr.aws/aws-containers/proton-demo-image:2d7f777"          
           minLength: 1
           maxLength: 200
         env_vars:


### PR DESCRIPTION
Use default backend that allows configurable PORT and Healthcheck to match the deployed applications' configuration.

These applications all listen on 3000.
* frontend
* nodejs
* crystal

Currently when the workshop is deployed, it uses the "public.ecr.aws/z9d2n7e1/nginx:1.19.5" image, which listens on 80 by default. It also does not have a /health endpoint. Because of this the targetgroup never successfully initializes and the ECS deployment never completes. Eventually after hours of ECS retrying, proton kills the deployment.

This change uses a new default backend that allows for a configurable PORT via envVar. The default healthcheck of the new backend is already /health so no reason to use that envVar. 

Only change required in the demo is when we ask user to put in envVars for service instance they need to PORT=3000 to each service. frontend, nodejs, and crystal. After that this gets the workshop working again.
