### PR TITLE
Remove reference to Proton preview CLI model

### DIFF
--- a/.github/workflows/proton_run.yml
+++ b/.github/workflows/proton_run.yml
@@ -226,12 +226,6 @@ jobs:
         aws-region: ${{ needs.get-deployment-data.outputs.proton_region }}
         role-to-assume: ${{ needs.get-deployment-data.outputs.role_arn }}
         role-session-name: TF-Github-Actions-Notify-Proton
-      
-    # This is a temporary measure until this feature exits Public Preview
-    - name: Install Proton Model
-      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-      run: |
-        aws s3 cp s3://aws-proton-preview-public-files/model/proton-2020-07-20.normal.json  .
 
     - name: Notify Proton Success
       id: notify_success


### PR DESCRIPTION
The removed section of code is no longer relevant as of Proton's GA release in 2021, and the functionality is part of the public release of the AWS CLI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
